### PR TITLE
Add cmockery2 support to Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,9 @@ sudo: true
 compiler:
     - gcc
 before_install:
-    - git clone https://github.com/lpabon/cmockery2.git
-    - cd cmockery2 && ./autogen.sh && ./configure --prefix=/usr && make && sudo make install
+    - sudo add-apt-repository ppa:lpabon/cmockery2 -y
+    - sudo apt-get -y update -q
+    - sudo apt-get -y install cmockery2 cmockery2-dev
 script:
+    - pkg-config --libs --cflags cmockery2
     - cd test_program && make

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,5 +5,4 @@ compiler:
 before_install:
     - bash .travis_cmockery2.sh
 script:
-    - pkg-config --libs --cflags cmockery2
     - cd test_program && make

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,9 @@
 language: c
+sudo: true
 compiler:
     - gcc
+before_install:
+    - git clone https://github.com/lpabon/cmockery2.git
+    - cd cmockery2 && ./autogen.sh && ./configure --prefix=/usr && make && sudo make install
 script:
     - cd test_program && make

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,7 @@ sudo: true
 compiler:
     - gcc
 before_install:
-    - sudo add-apt-repository ppa:lpabon/cmockery2 -y
-    - sudo apt-get -y update -q
-    - sudo apt-get -y install cmockery2 cmockery2-dev
+    - bash .travis_cmockery2.sh
 script:
     - pkg-config --libs --cflags cmockery2
     - cd test_program && make

--- a/.travis_cmockery2.sh
+++ b/.travis_cmockery2.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+git clone -b 1.3.9 https://github.com/lpabon/cmockery2.git
+cd cmockery2
+./autogen.sh || exit 1
+./configure --prefix=/usr || exit 1
+make || exit 1
+sudo make install || exit 1
+cd ..
+rm -rf cmockery2
+

--- a/.travis_cmockery2.sh
+++ b/.travis_cmockery2.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-git clone -b 1.3.9 https://github.com/lpabon/cmockery2.git
+git clone -b v1.3.9 https://github.com/lpabon/cmockery2.git
 cd cmockery2
 ./autogen.sh || exit 1
 ./configure --prefix=/usr || exit 1

--- a/test_program/Makefile
+++ b/test_program/Makefile
@@ -1,3 +1,6 @@
+TEST_CFLAGS=$(shell pkg-config --cflags cmockery2)
+TETS_LDFLAGS=$(shell pkg-config --libs cmockery2)
+
 test:md5.o sha1.o delete.o hash.o block.o stub.o catalog.o dedup.o Restore_file.o clean_buff.o dedup libdedup.a
 dedup.o:dedup.c dedup.h
 	gcc -c dedup.c -lssl -lcrypto 


### PR DESCRIPTION
Had to use git to setup cmockery2 since there is no package management in Ubuntu (which is what Travis runs).

Also, the Makefile now has support for cmockery2.
